### PR TITLE
Remove unneeded guard in method_missing

### DIFF
--- a/lib/batch_loader.rb
+++ b/lib/batch_loader.rb
@@ -70,8 +70,6 @@ class BatchLoader
   end
 
   def method_missing(method_name, *args, **opts, &block)
-    return unless __sync!.respond_to?(method_name)
-
     __sync!.public_send(method_name, *args, **opts, &block)
   end
 


### PR DESCRIPTION
This was initially added to try to fix an error when upgrading backend to Rails 7.0.8 but in the end it was not needed.